### PR TITLE
Fix capitalization of filenames in #include directives

### DIFF
--- a/src/Device/ClientReporter.h
+++ b/src/Device/ClientReporter.h
@@ -2,7 +2,7 @@
 #define ClientReporter_h
 
 #include <Device/DeviceDriver.h>
-#include <arduino.h>
+#include <Arduino.h>
 
 /**
  * This abstract class declares method signatures for any class that would like

--- a/src/Device/DeviceDriver.h
+++ b/src/Device/DeviceDriver.h
@@ -7,7 +7,7 @@
  *
  */
 
-#include <arduino.h>
+#include <Arduino.h>
 #include <stdlib.h>
 #include <string.h>
 #include <limits.h>

--- a/src/Device/LogicalUnitInfo.h
+++ b/src/Device/LogicalUnitInfo.h
@@ -1,7 +1,7 @@
 #ifndef LogicalUnitInfo_h
 #define LogicalUnitInfo_h
 
-#include <arduino.h>
+#include <Arduino.h>
 #include "DeviceDefine.h"
 
 class LogicalUnitInfo {


### PR DESCRIPTION
Incorrect capitalization of Arduino.h caused compilation to fail on filename case-sensitive operating systems like Linux.